### PR TITLE
AA - Fix memory leak from search component

### DIFF
--- a/src/app/events/events.page.ts
+++ b/src/app/events/events.page.ts
@@ -1,9 +1,9 @@
-import { Component, Input } from '@angular/core';
-import { EventsService } from '../../shared/services/events.service';
+import { Component, Input, ViewChild } from '@angular/core';
 import { Event } from 'src/shared/interfaces/Event';
 import { Subscription } from 'rxjs';
 import { User } from 'src/shared/interfaces/User';
 import { AuthService } from 'src/shared/services/auth.service';
+import { SearchComponent } from 'src/shared/components/search/search.component';
 
 @Component({
   selector: 'app-events',
@@ -14,6 +14,9 @@ export class EventsPage {
   parent: string = 'events';
   eventsData: Event[] = [];
   query: any = [];
+
+  @ViewChild(SearchComponent) searchComponent!: SearchComponent;
+
   private eventsSubscription: Subscription = new Subscription();
 
   @Input() titleColor: string = 'yellow';
@@ -46,6 +49,7 @@ export class EventsPage {
 
   ionViewWillEnter() {
     this.user = this.authService.getUserFromLocalStorage();
+    this.searchComponent.loadEventsBasedOnRoute();
   }
 
   getFilteredEvents(event: any): any {
@@ -64,6 +68,12 @@ export class EventsPage {
   ionViewDidLeave(): void {
     if (this.eventsSubscription) {
       this.eventsSubscription.unsubscribe();
+    }
+
+    // lifecycle hooks inside SearchComponent are not triggered
+    // unsubscribe from SearchComponent subscriptions
+    if (this.searchComponent.eventsSubscription) {
+      this.searchComponent.eventsSubscription.unsubscribe();
     }
   }
 }

--- a/src/app/favourites/favourites.page.ts
+++ b/src/app/favourites/favourites.page.ts
@@ -1,9 +1,10 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, ViewChild } from '@angular/core';
 import { EventsService } from '../../shared/services/events.service';
 import { Event } from 'src/shared/interfaces/Event';
 import { Subscription } from 'rxjs';
 import { User } from 'src/shared/interfaces/User';
 import { AuthService } from 'src/shared/services/auth.service';
+import { SearchComponent } from 'src/shared/components/search/search.component';
 
 @Component({
   selector: 'app-favourites',
@@ -14,6 +15,8 @@ export class FavouritesPage {
   parent: string = 'favourites';
   favouritesData: Event[] = [];
   query: any = [];
+
+  @ViewChild(SearchComponent) searchComponent!: SearchComponent;
 
   private favouritesSubscription: Subscription = new Subscription();
 
@@ -67,6 +70,7 @@ export class FavouritesPage {
 
   ionViewWillEnter(): void {
     this.user = this.authService.getUserFromLocalStorage();
+    this.searchComponent.loadEventsBasedOnRoute();
   }
 
   setLoading(isLoading: boolean): void {
@@ -85,6 +89,12 @@ export class FavouritesPage {
   ionViewDidLeave(): void {
     if (this.favouritesSubscription) {
       this.favouritesSubscription.unsubscribe();
+    }
+
+    // lifecycle hooks inside SearchComponent are not triggered
+    // unsubscribe from SearchComponent subscriptions
+    if (this.searchComponent.eventsSubscription) {
+      this.searchComponent.eventsSubscription.unsubscribe();
     }
   }
 }

--- a/src/shared/components/search/search.component.ts
+++ b/src/shared/components/search/search.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Subject, Subscription } from 'rxjs';
 import { Categories } from 'src/shared/data/categories';
 import BulgarianRegions from 'src/shared/data/regions';
@@ -18,7 +18,7 @@ export class SearchComponent {
   @Output() filteredEvents = new EventEmitter<any>();
   @Output() isLoadingEvents = new EventEmitter<boolean>();
 
-  private eventsSubscription: Subscription = new Subscription();
+  eventsSubscription!: Subscription;
 
   category: string = 'Категория';
   location: string = 'Регион';
@@ -43,24 +43,12 @@ export class SearchComponent {
     private eventService: EventsService,
     private activatedRoute: ActivatedRoute,
     private router: Router
-  ) {
-    this.router.events.subscribe((event) => {
-      if (event instanceof NavigationEnd) {
-        this.loadEventsBasedOnRoute();
-      }
-    });
-  }
-
-  ionViewWillEnter() {
-    if (this.externalSelectedCategory) {
-      this.selectedCategory = this.externalSelectedCategory;
-    }
-    this.loadEventsBasedOnRoute();
-  }
+  ) {}
 
   loadEventsBasedOnRoute(): void {
     const route = this.router.parseUrl(this.router.url);
     const queryParams = route.queryParamMap.keys;
+
     if (queryParams.includes('sortBy')) {
       // If 'sortBy' query parameter is present, update selectedCategory.
       const categoryToSort = route.queryParamMap.get('sortBy');
@@ -72,6 +60,7 @@ export class SearchComponent {
       route.queryParamMap.keys.length === 0
     ) {
       // If there are no query parameters, load all events and reset selectedCategory.
+
       this.selectedCategory = [];
       this.getEvents();
     } else {
@@ -128,7 +117,6 @@ export class SearchComponent {
 
   getEvents(query: string = '') {
     this.isLoadingEvents.emit(true);
-
     const fetchMethod =
       this.parent == 'favourites'
         ? () => this.eventService.getMyFavourites(query)
@@ -161,11 +149,5 @@ export class SearchComponent {
       queryParams: {},
       replaceUrl: true,
     });
-  }
-
-  ionViewDidLeave(): void {
-    if (this.eventsSubscription) {
-      this.eventsSubscription.unsubscribe();
-    }
   }
 }

--- a/src/shared/services/events.service.ts
+++ b/src/shared/services/events.service.ts
@@ -105,7 +105,6 @@ export class EventsService {
 
             // Remove the event from the favourite events subject
             if (eventIndex !== -1) {
-              console.log(eventId);
               this.unlikedEvent.next(eventId);
               favouriteEvents.splice(eventIndex, 1);
             }


### PR DESCRIPTION
The issue for the memory leak was that in the Search Component constructor, it was subscribing to the router, and after this on every route change it triggered this.loadEventsBasedOnRoute();

It was not possible to unsubscribe from ngOnDestroy, ionViewDidLeave, and ionViewWillLeave so we fixed the issue by getting the events from the parent.

Next step of refactoring can be to get the events from this parent component (events or favourites) - not from the search component as it is not its purpose